### PR TITLE
Add support for vscode 1.43 for FreeBSD

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"@types/glob": "^7.1.1",
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^13.11.0",
-		"@types/vscode": "^1.44.0",
+		"@types/vscode": "^1.43.0",
 		"@typescript-eslint/eslint-plugin": "^2.26.0",
 		"@typescript-eslint/parser": "^2.26.0",
 		"eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	},
 	"version": "1.0.1",
 	"engines": {
-		"vscode": "^1.44.0"
+		"vscode": "^1.43.0"
 	},
 	"categories": [
 		"Other"


### PR DESCRIPTION
FreeBSD currently uses 1.43. 

I updated (downgraded) the dependency this plugin requires and all appears to work.