### PR TITLE
Add VSCode Marketplace link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # zls-vscode
+
+[![VSCode Extension](https://img.shields.io/badge/vscode-extension-brightgreen)](https://marketplace.visualstudio.com/items?itemName=AugusteRame.zls-vscode)
+
 `zls-vscode` is a language client extension for [`zls`](https://github.com/zigtools/zls), the awesome Zig Language Server.
 
 ## Installing


### PR DESCRIPTION
### What
Add VSCode Marketplace link to readme.

### Why
It's not very discoverable from this repo to find the extension on the VSCode marketplace. I managed to find the link via an old issue that referenced it here https://github.com/zigtools/zls-vscode/issues/4#issuecomment-631723851. A link in the README would help with helping users know that the extension on the marketplace is this repo.

Similar to https://github.com/ziglang/vscode-zig/pull/61.