### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	},
 	"version": "1.0.4",
 	"engines": {
-		"vscode": "^1.47.1"
+		"vscode": "^1.68.0"
 	},
 	"categories": [
 		"Other"
@@ -75,19 +75,19 @@
 		"test": "node ./out/test/runTest.js"
 	},
 	"dependencies": {
-		"vscode-languageclient": "^7.0.0-next.9"
+		"vscode-languageclient": "8.0.2-next.5"
 	},
 	"devDependencies": {
-		"@types/glob": "^7.1.3",
-		"@types/mocha": "^7.0.2",
-		"@types/node": "^13.13.21",
-		"@types/vscode": "^1.47.1",
-		"@typescript-eslint/eslint-plugin": "^2.26.0",
-		"@typescript-eslint/parser": "^2.26.0",
-		"eslint": "^6.8.0",
-		"glob": "^7.1.6",
-		"mocha": "^7.1.1",
-		"typescript": "^3.9.7",
+		"@types/glob": "^7.2.0",
+		"@types/mocha": "^9.1.1",
+		"@types/node": "^18.0.0",
+		"@types/vscode": "^1.68.0",
+		"@typescript-eslint/eslint-plugin": "^5.29.0",
+		"@typescript-eslint/parser": "^5.29.0",
+		"eslint": "^8.18.0",
+		"glob": "^8.0.3",
+		"mocha": "^10.0.0",
+		"typescript": "^4.7.4",
 		"vscode-test": "^1.3.0"
 	}
 }


### PR DESCRIPTION
This will be required in order to be able to support latest features of LSP (like labelDetails)

It's not ready to get merged because there is a bug in ZLS

Removing this field fixes the issue: https://github.com/zigtools/zls/blob/fc5b1c64579e0ec33ea374051bcfef59ebfc0c5c/src/types.zig#L245

Something about ranges is wrong, i tried to investigate today, but i couldn't find the cause, so i just commented that line.. so far it seems to be ok

I'll try to spend more time on it tomorrow, since i need that to get sorted out to be able to send a PR to add labelDetails support
